### PR TITLE
Add StringIndent for pretty-printing JSON output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,32 @@ Will print:
 {"outter":{"inner":{"value":10,"value2":20},"inner2":{"value3":30}}}
 ```
 
+To pretty-print:
+
+```go
+...
+
+fmt.Println(jsonObj.StringIndent("", "  "))
+
+...
+
+Will print:
+
+```
+{
+  "outter": {
+    "inner": {
+      "value": 10,
+      "value2": 20
+    },
+    "inner2": {
+      "value3": 30
+    }
+  }
+}
+```
+```
+
 ###Generating Arrays
 
 ```go

--- a/gabs.go
+++ b/gabs.go
@@ -300,6 +300,18 @@ func (g *Container) String() string {
 }
 
 /*
+StringIndent - Converts the contained object back to a JSON formatted string with prefix and indent.
+*/
+func (g *Container) StringIndent(prefix string, indent string) string {
+	if g.object != nil {
+		if bytes, err := json.MarshalIndent(g.object, prefix, indent); err == nil {
+			return string(bytes)
+		}
+	}
+	return "{}"
+}
+
+/*
 New - Create a new gabs JSON object.
 */
 func New() *Container {

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -179,9 +179,16 @@ func TestExamples2(t *testing.T) {
 	jsonObj.ArrayAppend(20, "array")
 	jsonObj.ArrayAppend(30, "array")
 
-	expected = `{"array":[10,20,30]}`
-	if jsonObj.String() != expected {
-		t.Errorf("Non matched output: %v != %v", expected, jsonObj.String())
+	expected = `{
+      "array": [
+        10,
+        20,
+        30
+      ]
+    }`
+	result := jsonObj.StringIndent("    ", "  ")
+	if result != expected {
+		t.Errorf("Non matched output: %v != %v", expected, result)
 	}
 }
 


### PR DESCRIPTION
I'm using gabs to update a JSON file and would like to write a formatted JSON back to the file.

Since String() only provides an unformatted JSON, I added StringIndent which allows user to specify prefix and indent. String -> Marshal, StringIndent -> MarshalIndent.

I've updated one test to use StringIndent.
I've also verified that `go test` passed.