### PR TITLE
Allow parsing with buffer

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -26,6 +26,7 @@ package gabs
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"strings"
 )
@@ -57,6 +58,9 @@ var (
 
 	// ErrInvalidPath - The filepath was not valid.
 	ErrInvalidPath = errors.New("invalid file path")
+
+	// ErrInvalidBuffer - The input buffer contained an invalid JSON string
+	ErrInvalidBuffer = errors.New("input buffer contained invalid JSON")
 )
 
 /*---------------------------------------------------------------------------------------------------
@@ -517,6 +521,23 @@ func ParseJSONFile(path string) (*Container, error) {
 		return container, nil
 	}
 	return nil, ErrInvalidPath
+}
+
+/*
+ParseJSONBuffer - Read the contents of a buffer into a representation of the parsed JSON.
+*/
+func ParseJSONBuffer(buffer io.Reader) (*Container, error) {
+	var gabs Container
+	jsonDecoder := json.NewDecoder(buffer)
+	if err := jsonDecoder.Decode(&gabs.object); err != nil {
+		return nil, err
+	}
+
+	if _, ok := gabs.object.(map[string]interface{}); ok {
+		return &gabs, nil
+	}
+
+	return nil, ErrInvalidBuffer
 }
 
 /*---------------------------------------------------------------------------------------------------

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1,6 +1,7 @@
 package gabs
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -37,6 +38,16 @@ func TestBasic(t *testing.T) {
 
 	if result := val.Bytes(); string(result) != string(sample) {
 		t.Errorf("Wrong []byte conversion: %s != %s", result, sample)
+	}
+}
+
+func TestBasicWithBuffer(t *testing.T) {
+	sample := bytes.NewReader([]byte(`{"test":{"value":10},"test2":20}`))
+
+	_, err := ParseJSONBuffer(sample)
+	if err != nil {
+		t.Errorf("Failed to parse: %v", err)
+		return
 	}
 }
 


### PR DESCRIPTION
 - Added new ErrInvalidBuffer error
 - Added new ParseJSONBuffer function which accepts a standard io.Reader
 - Added a new TestBasicBuffer which does nothing but checks to make
   sure no errors occur in processing the json.

Resolves #7