### PR TITLE
Add support to json.Decoder

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -531,6 +531,19 @@ func ParseJSON(sample []byte) (*Container, error) {
 }
 
 /*
+ParseJSONDecoder - Convert a json.Decoder into a representation of the parsed JSON.
+*/
+func ParseJSONDecoder(decoder *json.Decoder) (*Container, error) {
+	var gabs Container
+
+	if err := decoder.Decode(&gabs.object); err != nil {
+		return nil, err
+	}
+
+	return &gabs, nil
+}
+
+/*
 ParseJSONFile - Read a file and convert into a representation of the parsed JSON.
 */
 func ParseJSONFile(path string) (*Container, error) {

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -110,6 +110,16 @@ func TestBasicWithDecoder(t *testing.T) {
 	checkNumber("test.float", "6.66")
 }
 
+func TestFailureWithDecoder(t *testing.T) {
+	sample := []byte(`{"test":{" "invalidCrap":.66}}`)
+	dec := json.NewDecoder(bytes.NewReader(sample))
+
+	_, err := ParseJSONDecoder(dec)
+	if err == nil {
+		t.Fatal("Expected parsing error")
+	}
+}
+
 func TestFindArray(t *testing.T) {
 	for i, this := range []struct {
 		input  string

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -84,6 +84,32 @@ func TestBasicWithBuffer(t *testing.T) {
 	}
 }
 
+func TestBasicWithDecoder(t *testing.T) {
+	sample := []byte(`{"test":{"int":10, "float":6.66}}`)
+	dec := json.NewDecoder(bytes.NewReader(sample))
+	dec.UseNumber()
+
+	val, err := ParseJSONDecoder(dec)
+	if err != nil {
+		t.Errorf("Failed to parse: %v", err)
+		return
+	}
+
+	checkNumber := func(path string, expectedVal json.Number) {
+		data := val.Path(path).Data()
+		asNumber, isNumber := data.(json.Number)
+		if !isNumber {
+			t.Error("Failed to parse using decoder UseNumber policy")
+		}
+		if expectedVal != asNumber {
+			t.Errorf("Expected[%s] but got [%s]", expectedVal, asNumber)
+		}
+	}
+
+	checkNumber("test.int", "10")
+	checkNumber("test.float", "6.66")
+}
+
 func TestFindArray(t *testing.T) {
 	for i, this := range []struct {
 		input  string


### PR DESCRIPTION
Hi,

I had some problems differentiating float from int when decoding, and a good solution was to get access to the JSON number representation (the raw form, which is a string).

In Go, the only way to do this (that I know of course :-), is by using the decoder.UseNumber(). The code that I have written here has some tests and Im already using on my project, it succeeded on solving my problem :-)

I hope it can be helpful to other people.