### PR TITLE
Fix Delete

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -283,9 +283,11 @@ func (g *Container) Delete(path ...string) error {
 	for target := 0; target < len(path); target++ {
 		if mmap, ok := object.(map[string]interface{}); ok {
 			if target == len(path)-1 {
-				delete(mmap, path[target])
-			} else if mmap[path[target]] == nil {
-				return ErrNotObj
+				if _, ok := mmap[path[target]]; ok {
+					delete(mmap, path[target])
+				} else {
+					return ErrNotObj
+				}
 			}
 			object = mmap[path[target]]
 		} else {

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -247,6 +247,11 @@ func TestDeletes(t *testing.T) {
 				"value1":20,
 				"value2":42,
 				"value3":92
+			},
+			"another":{
+				"value1":null,
+				"value2":null,
+				"value3":null
 			}
 		}
 	}`))
@@ -254,11 +259,29 @@ func TestDeletes(t *testing.T) {
 	if err := jsonParsed.Delete("outter", "inner", "value2"); err != nil {
 		t.Error(err)
 	}
+	if err := jsonParsed.Delete("outter", "inner", "value4"); err == nil {
+		t.Error(fmt.Errorf("value4 should not have been found in outter.inner"))
+	}
+	if err := jsonParsed.Delete("outter", "another", "value1"); err != nil {
+		t.Error(err)
+	}
+	if err := jsonParsed.Delete("outter", "another", "value4"); err == nil {
+		t.Error(fmt.Errorf("value4 should not have been found in outter.another"))
+	}
 	if err := jsonParsed.DeleteP("outter.alsoInner.value1"); err != nil {
 		t.Error(err)
 	}
+	if err := jsonParsed.DeleteP("outter.alsoInner.value4"); err == nil {
+		t.Error(fmt.Errorf("value4 should not have been found in outter.alsoInner"))
+	}
+	if err := jsonParsed.DeleteP("outter.another.value2"); err != nil {
+		t.Error(err)
+	}
+	if err := jsonParsed.Delete("outter.another.value4"); err == nil {
+		t.Error(fmt.Errorf("value4 should not have been found in outter.another"))
+	}
 
-	expected := `{"outter":{"alsoInner":{"value2":42,"value3":92},"inner":{"value1":10,"value3":32}}}`
+	expected := `{"outter":{"alsoInner":{"value2":42,"value3":92},"another":{"value3":null},"inner":{"value1":10,"value3":32}}}`
 	if actual := jsonParsed.String(); actual != expected {
 		t.Errorf("Unexpected result from deletes: %v != %v", actual, expected)
 	}


### PR DESCRIPTION
Delete wouldn't yield an error if the key didn't exist.

Delete also checked if the _value_ was null, not if the _key_ didn't exist.