### PR TITLE
Support HTML escaping

### DIFF
--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1068,7 +1068,7 @@ func TestBadIndexes(t *testing.T) {
 }
 
 func TestNilSet(t *testing.T) {
-	obj := Container{nil}
+	obj := Container{nil, true}
 	if _, err := obj.Set("bar", "foo"); err != nil {
 		t.Error(err)
 	}
@@ -1077,5 +1077,49 @@ func TestNilSet(t *testing.T) {
 	}
 	if _, err := obj.SetIndex("new", 0); err != ErrNotArray {
 		t.Errorf("Expected ErrNotArray: %v, %s", err, obj.Data())
+	}
+}
+
+func TestLargeSampleWithHtmlEscape(t *testing.T) {
+	sample := []byte(`{
+	"test": {
+		"innerTest": {
+			"value": 10,
+			"value2": "<title>Title</title>",
+			"value3": {
+				"moreValue": 45
+			}
+		}
+	},
+	"test2": 20
+}`)
+
+	sampleWithHtmlEscape := []byte(`{
+	"test": {
+		"innerTest": {
+			"value": 10,
+			"value2": "\u003ctitle\u003eTitle\u003c/title\u003e",
+			"value3": {
+				"moreValue": 45
+			}
+		}
+	},
+	"test2": 20
+}`)
+
+	val, err := ParseJSON(sample)
+	if err != nil {
+		t.Errorf("Failed to parse: %v", err)
+		return
+	}
+
+	obj := Container{val.Data(), false}
+	if string(obj.BytesIndent("", "\t")) != string(sample) {
+		t.Errorf("Wrong conversion without html escaping: %s != %s", obj.BytesIndent("", "\t"), sample)
+	}
+
+	objWithHtmlEscape := Container{val.Data(), true}
+	if string(objWithHtmlEscape.BytesIndent("", "\t")) != string(sampleWithHtmlEscape) {
+		t.Errorf("Wrong conversion with html escaping: %s != %s", objWithHtmlEscape.BytesIndent("", "\t"), sampleWithHtmlEscape)
 	}
 }


### PR DESCRIPTION
To Support HTML escaping when encoding json,
I modified `Bytes()` and `BytesIndent()` to use `encoding/json.NewEncoder()` with `encoding/json.SetEscapeHTML()`.
Because `encoding/json.Marshal` doesn't support HTML escaping

* Add `isHtmlEscape bool` in `type Container struct`
* Add `func (g *Container) SetHtmlEscape(isHtmlEscape bool)`
* Modify `func (g *Container) Bytes() []byte` and `func (g *Container) BytesIndent(prefix string, indent string) []byte`
* Add `func TestLargeSampleWithHtmlEscape(t *testing.T)`