### PR TITLE
Add DeleteAll function

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -304,6 +304,16 @@ func (g *Container) Delete(path ...string) error {
 	return nil
 }
 
+func (g *Container) DeleteAll(elements []string) error {
+	for _, element := range(elements) {
+		err := g.Delete(element)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DeleteP - Does the same as Delete, but using a dot notation JSON path.
 func (g *Container) DeleteP(path string) error {
 	return g.Delete(strings.Split(path, ".")...)


### PR DESCRIPTION
Sometimes I want to delete several elements by using one function.

Suppose we have to delete 6 elements which named "e1", "e2", "e3"... 

We could use 'Delete' function 6 times.

```
someJSONObject.Delete("e1")
someJSONObject.Delete("e2")
someJSONObject.Delete("e3")
someJSONObject.Delete("e4")
someJSONObject.Delete("e5")
someJSONObject.Delete("e6")

```

But how about this? Much more clear and sharp IMHO.

```
someJSONObject.DeleteAll([]string {"e1", "e2", "e3", "e4", "e5", "e6",})
```

It would be my honor if you consider my idea. Thank you. 😄 