### PR TITLE
update README with correct usage of Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ jsonParsed, err := gabs.ParseJSON([]byte(`{"array":[{"value":1},{"value":2},{"va
 if err != nil {
 	panic(err)
 }
-fmt.Println(jsonParsed.Path("array.value.1").String())
+fmt.Println(jsonParsed.Path("array.1.value").String())
 ```
 
 Will print `2`.


### PR DESCRIPTION
In the 'Searching through arrays' section, fixed a typo in the statement demonstrating the use of function Path.
<img width="956" alt="Screenshot 2019-08-15 at 8 41 57 PM" src="https://user-images.githubusercontent.com/51126363/63121960-97428300-bf9d-11e9-88ca-0e8bd1ef2e4d.png">
