### PR TITLE
Add continuous fuzzing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,25 @@
+dist: bionic
 language: go
+go:
+  - "1.12.x"
+
+services:
+  - docker
+
+env:
+  global:
+    # FUZZIT_API_KEY
+    secure: "FEm1wF/Ttd5RIvDPg5I/aSAhBWuvkvjmkInFxlVKP4BfLsR1B1ogXV4zKFQiZugyppBta+qP4qP+tSbThSvP9JOCr+/ivnTyYLg/DH1RfQnC7rJmAaZwHGHB+NwblRzU621uIZ4RVvaE391YVJf5519gc+M+bxZ6DO0ScdpbIAVV/7JR9c7Tuvoyi57/MEwAS39k7h83ms8JgRYwuvzpVH9nb6AfYs+CzXuRlsG5mHqFnmzLyG0ewnqh18OoWbyKQwBmM+EoIGmckM8NQZaXWBhEuDP7qdl+QatNfZtK3YwBx2plahBXXMee3NpOAEHOkWxNw1uMb1B8ILDrzrx8oX1A4fF/ZeJl7JLZS/fQUMhDnLG5soA0xaEoAvwhQIHFi3e207rsq9UJsnQlRGhRWzMvx85UR5z+yiur8nVUkogu1DGpH/BPdWbTs+d8behSr7t6Sepo7enjJOPJLz6U67JlP31HvnaLICMEXxJy54BAbdu/47vqFp15lcIMHyDzPltHHWi6uGuRFQPYz8pM5ZAKQ945dO/ZELyEHbjUiLTMFeVoANzahuY56BX6hvsygcOlBWB6ukoJANvxgvM/QYkbh9dMBajYsZqHCWOKRVbBakkqPAUqkBNPOADTp5ZgUwmRySIGzX2X+Efl7cFYZVu+IJl968F8hqYajvS/VCs="
+
+jobs:
+  include:
+    - stage: Test
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh local-regression
+
+    - stage: Fuzz
+      if: type IN (push)
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh fuzzing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Gabs](gabs_logo.png "Gabs")
 
-[![godoc for Jeffail/gabs][godoc-badge]][godoc-url]
+[![godoc for Jeffail/gabs][godoc-badge]][godoc-url] [![fuzzit](https://app.fuzzit.dev/badge?org_id=Jeffail)](https://app.fuzzit.dev/orgs/Jeffail/dashboard)
 
 Gabs is a small utility for dealing with dynamic or unknown JSON structures in Go. It's pretty much just a helpful wrapper for navigating hierarchies of `map[string]interface{}` objects provided by the `encoding/json` package. It does nothing spectacular apart from being fabulous.
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -xe
+
+NAME=gabs
+
+## Build fuzzing targets
+## go-fuzz doesn't support modules for now, so ensure we do everything
+## in the old style GOPATH way
+export GO111MODULE="off"
+
+## Install go-fuzz
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+# download dependencies into ${GOPATH}
+# -d : only download (don't install)f
+# -v : verbose
+# -u : use the latest version
+# will be different if you use vendoring or a dependency manager
+# like godep
+go get -d -v -u ./...
+
+go-fuzz-build -libfuzzer -o $NAME.a .
+clang -fsanitize=fuzzer $NAME.a -o $NAME
+
+## Install fuzzit specific version for production or latest version for development :
+# https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+## upload fuzz target for long fuzz testing on fuzzit.dev server or run locally for regression
+./fuzzit create job --type ${1} $NAME $NAME

--- a/gabs_fuzz.go
+++ b/gabs_fuzz.go
@@ -1,0 +1,12 @@
+// +build gofuzz
+
+package gabs
+
+func Fuzz(input []byte) int {
+	result, err := ParseJSON(input)
+	if err != nil {
+		return 0
+	}
+	result.String()
+	return 1
+}


### PR DESCRIPTION
Hello. I wonder if you'd like to set up fuzzing? Fuzzit offers free service for open source projects. It's well suited to a parser.

This patch sets up Travis CI with a Fuzzit integration. There are a few external things that would need setting up. It's like this:
* Join [Travis](https://travis-ci.org/) and activate this repo.
* Join [Fuzzit](https://fuzzit.dev/). Create a target `gabs`.
* Go to Fuzzit settings and grab an API key. In Travis go to the repo settings and paste it as envvar `FUZZIT_API_KEY`.

Fuzzing target parses the fuzz then encodes back to string to catch any errors on the full round trip.

I ran a fuzz overnight. No bugs found so far. It seems to be in good shape.