### PR TITLE
added support for JSON marshaling #70

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -774,4 +774,11 @@ func ParseJSONBuffer(buffer io.Reader) (*Container, error) {
 	return &gabs, nil
 }
 
+// MarshalJson returns the JSON encoding of this container. This allows
+// structs which contain Container instances to be marshaled using
+// json.Marshal().
+func (g *Container) MarshalJSON() ([]byte, error) {
+	return json.Marshal(g.Data())
+}
+
 //------------------------------------------------------------------------------

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strings"
 	"testing"
@@ -1676,4 +1677,16 @@ func TestMergeCases(t *testing.T) {
 			t.Errorf("[%d] Wrong result: %v != %v", i, act, exp)
 		}
 	}
+}
+
+func TestMarshalsJSON(t *testing.T) {
+	sample := []byte(`{"test":{"value":10},"test2":20}`)
+
+	val, err := ParseJSON(sample)
+	assert.NoError(t, err)
+
+	marshaled, err := json.Marshal(val)
+	assert.NoError(t, err)
+	fmt.Println(marshaled)
+	assert.Equal(t, sample, marshaled)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/Jeffail/gabs/v2
+
+go 1.12


### PR DESCRIPTION
This PR addresses issue #70 and adds support for JSON marshaling using `json.Marshal` and `json.MarshalIndent`. Thanks a bunch for this lib by the way, @Jeffail - really handy.