### PR TITLE
Handling flattening of an empty object as an empty struct

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -738,19 +738,6 @@ func walkArray(path string, arr []interface{}, flat map[string]interface{}, incl
 	}
 }
 
-func (g *Container) flatten(includeEmpty bool) (map[string]interface{}, error) {
-	flattened := map[string]interface{}{}
-	switch t := g.Data().(type) {
-	case map[string]interface{}:
-		walkObject("", t, flattened, includeEmpty)
-	case []interface{}:
-		walkArray("", t, flattened, includeEmpty)
-	default:
-		return nil, ErrNotObjOrArray
-	}
-	return flattened, nil
-}
-
 // Flatten a JSON array or object into an object of key/value pairs for each
 // field, where the key is the full path of the structured field in dot path
 // notation matching the spec for the method Path.
@@ -775,6 +762,19 @@ func (g *Container) Flatten() (map[string]interface{}, error) {
 // Returns an error if the target is not a JSON object or array.
 func (g *Container) FlattenIncludeEmpty() (map[string]interface{}, error) {
 	return g.flatten(true)
+}
+
+func (g *Container) flatten(includeEmpty bool) (map[string]interface{}, error) {
+	flattened := map[string]interface{}{}
+	switch t := g.Data().(type) {
+	case map[string]interface{}:
+		walkObject("", t, flattened, includeEmpty)
+	case []interface{}:
+		walkArray("", t, flattened, includeEmpty)
+	default:
+		return nil, ErrNotObjOrArray
+	}
+	return flattened, nil
 }
 
 //------------------------------------------------------------------------------

--- a/gabs.go
+++ b/gabs.go
@@ -700,6 +700,10 @@ func (g *Container) ArrayCountP(path string) (int, error) {
 //------------------------------------------------------------------------------
 
 func walkObject(path string, obj map[string]interface{}, flat map[string]interface{}) {
+	if len(obj) == 0 {
+		flat[path] = struct{}{}
+	}
+
 	for elePath, v := range obj {
 		if len(path) > 0 {
 			elePath = path + "." + elePath

--- a/gabs.go
+++ b/gabs.go
@@ -720,6 +720,9 @@ func walkObject(path string, obj map[string]interface{}, flat map[string]interfa
 }
 
 func walkArray(path string, arr []interface{}, flat map[string]interface{}) {
+	if len(arr) == 0 {
+		flat[path] = []struct{}{}
+	}
 	for i, ele := range arr {
 		elePath := strconv.Itoa(i)
 		if len(path) > 0 {

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1814,6 +1814,58 @@ func TestFlatten(t *testing.T) {
 		},
 		{
 			input:  `{"foo":{"bar":{}}}`,
+			output: `{}`,
+		},
+		{
+			input:  `{"foo":{"bar":[]}}`,
+			output: `{}`,
+		},
+	}
+
+	for _, test := range tests {
+		gObj, err := ParseJSON([]byte(test.input))
+		if err != nil {
+			t.Fatalf("Failed to parse '%v': %v", test.input, err)
+		}
+		var res map[string]interface{}
+		if res, err = gObj.Flatten(); err != nil {
+			t.Error(err)
+			continue
+		}
+		if exp, act := test.output, Wrap(res).String(); exp != act {
+			t.Errorf("Wrong result: %v != %v", act, exp)
+		}
+	}
+}
+
+func TestFlattenIncludeEmpty(t *testing.T) {
+	type testCase struct {
+		input  string
+		output string
+	}
+	tests := []testCase{
+		{
+			input:  `{"foo":{"bar":"baz"}}`,
+			output: `{"foo.bar":"baz"}`,
+		},
+		{
+			input:  `{"foo":[{"bar":"1"},{"bar":"2"}]}`,
+			output: `{"foo.0.bar":"1","foo.1.bar":"2"}`,
+		},
+		{
+			input:  `[{"bar":"1"},{"bar":"2"}]`,
+			output: `{"0.bar":"1","1.bar":"2"}`,
+		},
+		{
+			input:  `[["1"],["2","3"]]`,
+			output: `{"0.0":"1","1.0":"2","1.1":"3"}`,
+		},
+		{
+			input:  `{"foo":{"bar":null}}`,
+			output: `{"foo.bar":null}`,
+		},
+		{
+			input:  `{"foo":{"bar":{}}}`,
 			output: `{"foo.bar":{}}`,
 		},
 		{
@@ -1828,7 +1880,7 @@ func TestFlatten(t *testing.T) {
 			t.Fatalf("Failed to parse '%v': %v", test.input, err)
 		}
 		var res map[string]interface{}
-		if res, err = gObj.Flatten(); err != nil {
+		if res, err = gObj.FlattenIncludeEmpty(); err != nil {
 			t.Error(err)
 			continue
 		}

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1816,6 +1816,10 @@ func TestFlatten(t *testing.T) {
 			input:  `{"foo":{"bar":{}}}`,
 			output: `{"foo.bar":{}}`,
 		},
+		{
+			input:  `{"foo":{"bar":[]}}`,
+			output: `{"foo.bar":[]}`,
+		},
 	}
 
 	for _, test := range tests {

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1808,6 +1808,14 @@ func TestFlatten(t *testing.T) {
 			input:  `[["1"],["2","3"]]`,
 			output: `{"0.0":"1","1.0":"2","1.1":"3"}`,
 		},
+		{
+			input:  `{"foo":{"bar":null}}`,
+			output: `{"foo.bar":null}`,
+		},
+		{
+			input:  `{"foo":{"bar":{}}}`,
+			output: `{"foo.bar":{}}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We had some strange behavior with the json flattener in benthos. 

This, I believe, solves it and seems to most accurately match the json marshaling in go (an empty struct.) Similar logic was added for empty arrays. I'm wondering if there are any edge cases I'm not seeing here. Also added a test case for nulls. 

Let me know if this works for you or if you'd like to see any modifications! Thanks!!

related #76 