### PR TITLE
Support nested array wildcard deletion

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -463,6 +463,17 @@ func (g *Container) Delete(hierarchy ...string) error {
 		if len(hierarchy) < 2 {
 			return errors.New("unable to delete array index at root of path")
 		}
+
+		// delete within one nested wildcard level
+		if hierarchy[1] == "*" {
+			for i := range array {
+				if obj, ok := array[i].(map[string]interface{}); ok {
+					delete(obj, target)
+				}
+			}
+			return nil
+		}
+
 		index, err := strconv.Atoi(target)
 		if err != nil {
 			return fmt.Errorf("failed to parse array index '%v': %v", target, err)

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -669,6 +669,19 @@ func TestDeletesWithArrays(t *testing.T) {
 	if actual := jsonParsed.String(); actual != expected {
 		t.Errorf("Unexpected result from array deletes: %v != %v", actual, expected)
 	}
+
+	jsonParsed, err = ParseJSON([]byte(rawJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = jsonParsed.Delete("outter", "*", "bar"); err != nil {
+		t.Error(err)
+	}
+
+	expected = `{"outter":[{"foo":{"value1":10,"value2":22,"value3":32}},{"baz":{"value1":null,"value2":null,"value3":null}}]}`
+	if actual := jsonParsed.String(); actual != expected {
+		t.Errorf("Unexpected result from array deletes: %v != %v", actual, expected)
+	}
 }
 
 func TestExamples(t *testing.T) {


### PR DESCRIPTION
I added support for deletes that affect all entries within an array.
This way, delete operations of the form `outer.*.bar` will work.

Hope this makes sense! Let me know if I missed anything :)