### PR TITLE
Add linter and CI

### DIFF
--- a/.errcheck.txt
+++ b/.errcheck.txt
@@ -1,0 +1,8 @@
+(*github.com/Jeffail/gabs/v2.Container).Array
+(*github.com/Jeffail/gabs/v2.Container).ArrayAppend
+(*github.com/Jeffail/gabs/v2.Container).ArrayAppend
+(*github.com/Jeffail/gabs/v2.Container).ArrayConcat
+(*github.com/Jeffail/gabs/v2.Container).ArrayConcatP
+(*github.com/Jeffail/gabs/v2.Container).ArrayP
+(*github.com/Jeffail/gabs/v2.Container).Set
+(*github.com/Jeffail/gabs/v2.Container).SetIndex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Tidy
+        run: go mod tidy && git diff-index --quiet HEAD || { >&2 echo "Stale go.{mod,sum} detected. This can be fixed with 'go mod tidy'."; exit 1; }
+
+      - name: Test
+        run: go test -count 100 ./...
+
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,22 +20,22 @@ linters:
   disable-all: true
   enable:
     # Default linters reported by golangci-lint help linters` in v1.39.0
-    - deadcode
-    - errcheck
     - gosimple
-    - govet
-    - gosimple
-    - ineffassign
     - staticcheck
-    - structcheck
-    - stylecheck
-    - typecheck
     - unused
-    - varcheck
+    - errcheck
+    - govet
+    - ineffassign
+    - typecheck
     # Extra linters:
+    - wastedassign
+    - stylecheck
     - gofmt
     - goimports
     - gocritic
     - revive
-    - bodyclose
+    - unconvert
+    - durationcheck
+    - depguard
     - gosec
+    - bodyclose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,41 @@
+run:
+  timeout: 30s
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters-settings:
+  errcheck:
+    exclude: .errcheck.txt
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+
+linters:
+  disable-all: true
+  enable:
+    # Default linters reported by golangci-lint help linters` in v1.39.0
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - gosimple
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unused
+    - varcheck
+    # Extra linters:
+    - gofmt
+    - goimports
+    - gocritic
+    - revive
+    - bodyclose
+    - gosec

--- a/gabs.go
+++ b/gabs.go
@@ -97,8 +97,8 @@ func JSONPointerToSlice(path string) ([]string, error) {
 	}
 	hierarchy := strings.Split(path, "/")[1:]
 	for i, v := range hierarchy {
-		v = strings.Replace(v, "~1", "/", -1)
-		v = strings.Replace(v, "~0", "~", -1)
+		v = strings.ReplaceAll(v, "~1", "/")
+		v = strings.ReplaceAll(v, "~0", "~")
 		hierarchy[i] = v
 	}
 	return hierarchy, nil
@@ -112,8 +112,8 @@ func JSONPointerToSlice(path string) ([]string, error) {
 func DotPathToSlice(path string) []string {
 	hierarchy := strings.Split(path, ".")
 	for i, v := range hierarchy {
-		v = strings.Replace(v, "~1", ".", -1)
-		v = strings.Replace(v, "~0", "~", -1)
+		v = strings.ReplaceAll(v, "~1", ".")
+		v = strings.ReplaceAll(v, "~0", "~")
 		hierarchy[i] = v
 	}
 	return hierarchy

--- a/gabs.go
+++ b/gabs.go
@@ -86,7 +86,7 @@ var (
 // gabs paths, '~' needs to be encoded as '~0' and '/' needs to be encoded as
 // '~1' when these characters appear in a reference key.
 func JSONPointerToSlice(path string) ([]string, error) {
-	if len(path) == 0 {
+	if path == "" {
 		return nil, nil
 	}
 	if path[0] != '/' {

--- a/gabs.go
+++ b/gabs.go
@@ -784,8 +784,8 @@ func (g *Container) flatten(includeEmpty bool) (map[string]interface{}, error) {
 
 // Bytes marshals an element to a JSON []byte blob.
 func (g *Container) Bytes() []byte {
-	if bytes, err := json.Marshal(g.Data()); err == nil {
-		return bytes
+	if data, err := json.Marshal(g.Data()); err == nil {
+		return data
 	}
 	return []byte("null")
 }
@@ -794,8 +794,8 @@ func (g *Container) Bytes() []byte {
 // and indent string.
 func (g *Container) BytesIndent(prefix string, indent string) []byte {
 	if g.object != nil {
-		if bytes, err := json.MarshalIndent(g.Data(), prefix, indent); err == nil {
-			return bytes
+		if data, err := json.MarshalIndent(g.Data(), prefix, indent); err == nil {
+			return data
 		}
 	}
 	return []byte("null")

--- a/gabs.go
+++ b/gabs.go
@@ -28,7 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -887,7 +887,7 @@ func ParseJSONDecoder(decoder *json.Decoder) (*Container, error) {
 // ParseJSONFile reads a file and unmarshals the contents into a *Container.
 func ParseJSONFile(path string) (*Container, error) {
 	if len(path) > 0 {
-		cBytes, err := ioutil.ReadFile(path)
+		cBytes, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/gabs.go
+++ b/gabs.go
@@ -501,7 +501,9 @@ func (g *Container) MergeFn(source *Container, collisionFn func(destination, sou
 	var recursiveFnc func(map[string]interface{}, []string) error
 	recursiveFnc = func(mmap map[string]interface{}, path []string) error {
 		for key, value := range mmap {
-			newPath := append(path, key)
+			newPath := make([]string, len(path))
+			copy(newPath, path)
+			newPath = append(newPath, key)
 			if g.Exists(newPath...) {
 				existingData := g.Search(newPath...).Data()
 				switch t := value.(type) {

--- a/gabs.go
+++ b/gabs.go
@@ -519,11 +519,9 @@ func (g *Container) MergeFn(source *Container, collisionFn func(destination, sou
 						return err
 					}
 				}
-			} else {
+			} else if _, err := g.Set(value, newPath...); err != nil {
 				// path doesn't exist. So set the value
-				if _, err := g.Set(value, newPath...); err != nil {
-					return err
-				}
+				return err
 			}
 		}
 		return nil

--- a/gabs.go
+++ b/gabs.go
@@ -702,7 +702,7 @@ func (g *Container) ArrayCountP(path string) (int, error) {
 
 //------------------------------------------------------------------------------
 
-func walkObject(path string, obj map[string]interface{}, flat map[string]interface{}, includeEmpty bool) {
+func walkObject(path string, obj, flat map[string]interface{}, includeEmpty bool) {
 	if includeEmpty && len(obj) == 0 {
 		flat[path] = struct{}{}
 	}
@@ -792,7 +792,7 @@ func (g *Container) Bytes() []byte {
 
 // BytesIndent marshals an element to a JSON []byte blob formatted with a prefix
 // and indent string.
-func (g *Container) BytesIndent(prefix string, indent string) []byte {
+func (g *Container) BytesIndent(prefix, indent string) []byte {
 	if g.object != nil {
 		if data, err := json.MarshalIndent(g.Data(), prefix, indent); err == nil {
 			return data
@@ -808,7 +808,7 @@ func (g *Container) String() string {
 
 // StringIndent marshals an element to a JSON string formatted with a prefix and
 // indent string.
-func (g *Container) StringIndent(prefix string, indent string) string {
+func (g *Container) StringIndent(prefix, indent string) string {
 	return string(g.BytesIndent(prefix, indent))
 }
 
@@ -823,7 +823,7 @@ func EncodeOptHTMLEscape(doEscape bool) EncodeOpt {
 }
 
 // EncodeOptIndent sets the encoder to indent the JSON output.
-func EncodeOptIndent(prefix string, indent string) EncodeOpt {
+func EncodeOptIndent(prefix, indent string) EncodeOpt {
 	return func(e *json.Encoder) {
 		e.SetIndent(prefix, indent)
 	}

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -972,11 +972,11 @@ func TestModify(t *testing.T) {
 		t.Errorf("Didn't find test.value")
 	}
 
-	if out := val.String(); `{"test":{"value":45},"test2":20}` != out {
+	if out := val.String(); out != `{"test":{"value":45},"test2":20}` {
 		t.Errorf("Incorrectly serialized: %v", out)
 	}
 
-	if out := val.Search("test").String(); `{"value":45}` != out {
+	if out := val.Search("test").String(); out != `{"value":45}` {
 		t.Errorf("Incorrectly serialized: %v", out)
 	}
 }
@@ -1069,15 +1069,15 @@ func TestChildrenMap(t *testing.T) {
 	}
 
 	for key, val := range objectMap {
-		if "objectOne" == key {
+		if key == "objectOne" {
 			if val := val.S("num").Data().(float64); val != 1 {
 				t.Errorf("%v != %v", val, 1)
 			}
-		} else if "objectTwo" == key {
+		} else if key == "objectTwo" {
 			if val := val.S("num").Data().(float64); val != 2 {
 				t.Errorf("%v != %v", val, 2)
 			}
-		} else if "objectThree" == key {
+		} else if key == "objectThree" {
 			if val := val.S("num").Data().(float64); val != 3 {
 				t.Errorf("%v != %v", val, 3)
 			}
@@ -1494,7 +1494,7 @@ func TestInvalid(t *testing.T) {
 	}
 
 	invalidStr := validObj.S("Doesn't exist").String()
-	if "null" != invalidStr {
+	if invalidStr != "null" {
 		t.Errorf("expected 'null', received: %v", invalidStr)
 	}
 }
@@ -1634,10 +1634,10 @@ func TestBadIndexes(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if act := jsonObj.Index(0).Data(); nil != act {
+	if act := jsonObj.Index(0).Data(); act != nil {
 		t.Errorf("Unexpected value returned: %v != %v", nil, act)
 	}
-	if act := jsonObj.S("array").Index(4).Data(); nil != act {
+	if act := jsonObj.S("array").Index(4).Data(); act != nil {
 		t.Errorf("Unexpected value returned: %v != %v", nil, act)
 	}
 }

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1422,7 +1422,7 @@ func TestLargeSample(t *testing.T) {
 }
 
 func TestShorthand(t *testing.T) {
-	json, _ := ParseJSON([]byte(`{
+	container, _ := ParseJSON([]byte(`{
 		"outter":{
 			"inner":{
 				"value":5,
@@ -1437,24 +1437,24 @@ func TestShorthand(t *testing.T) {
 		}
 	}`))
 
-	missingValue := json.S("outter").S("doesntexist").S("alsodoesntexist").S("inner").S("value").Data()
+	missingValue := container.S("outter").S("doesntexist").S("alsodoesntexist").S("inner").S("value").Data()
 	if missingValue != nil {
 		t.Errorf("missing value was actually found: %v\n", missingValue)
 	}
 
-	realValue := json.S("outter").S("inner").S("value2").Data().(float64)
+	realValue := container.S("outter").S("inner").S("value2").Data().(float64)
 	if realValue != 10 {
 		t.Errorf("real value was incorrect: %v\n", realValue)
 	}
 
-	_, err := json.S("outter2").Set(json.S("outter").S("inner").Data(), "inner")
+	_, err := container.S("outter2").Set(container.S("outter").S("inner").Data(), "inner")
 	if err != nil {
 		t.Errorf("error setting outter2: %v\n", err)
 	}
 
 	compare := `{"outter":{"inner":{"value":5,"value2":10,"value3":11},"inner2":{}}` +
 		`,"outter2":{"inner":{"value":5,"value2":10,"value3":11}}}`
-	out := json.String()
+	out := container.String()
 	if out != compare {
 		t.Errorf("wrong serialized structure: %v\n", out)
 	}
@@ -1462,8 +1462,8 @@ func TestShorthand(t *testing.T) {
 	compare2 := `{"outter":{"inner":{"value":6,"value2":10,"value3":11},"inner2":{}}` +
 		`,"outter2":{"inner":{"value":6,"value2":10,"value3":11}}}`
 
-	json.S("outter").S("inner").Set(6, "value")
-	out = json.String()
+	container.S("outter").S("inner").Set(6, "value")
+	out = container.String()
 	if out != compare2 {
 		t.Errorf("wrong serialized structure: %v\n", out)
 	}
@@ -1500,8 +1500,8 @@ func TestInvalid(t *testing.T) {
 }
 
 func TestCreation(t *testing.T) {
-	json, _ := ParseJSON([]byte(`{}`))
-	inner, err := json.ObjectP("test.inner")
+	container, _ := ParseJSON([]byte(`{}`))
+	inner, err := container.ObjectP("test.inner")
 	if err != nil {
 		t.Errorf("Error: %v", err)
 		return
@@ -1517,7 +1517,7 @@ func TestCreation(t *testing.T) {
 
 	expected := `{"test":{"inner":{"array":["first element of the array",2,"three"],` +
 		`"first":10,"second":20}}}`
-	actual := json.String()
+	actual := container.String()
 	if actual != expected {
 		t.Errorf("received incorrect output from json object: %v\n", actual)
 	}

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1069,19 +1069,20 @@ func TestChildrenMap(t *testing.T) {
 	}
 
 	for key, val := range objectMap {
-		if key == "objectOne" {
+		switch key {
+		case "objectOne":
 			if val := val.S("num").Data().(float64); val != 1 {
 				t.Errorf("%v != %v", val, 1)
 			}
-		} else if key == "objectTwo" {
+		case "objectTwo":
 			if val := val.S("num").Data().(float64); val != 2 {
 				t.Errorf("%v != %v", val, 2)
 			}
-		} else if key == "objectThree" {
+		case "objectThree":
 			if val := val.S("num").Data().(float64); val != 3 {
 				t.Errorf("%v != %v", val, 3)
 			}
-		} else {
+		default:
 			t.Errorf("Unexpected key: %v", key)
 		}
 	}

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -707,6 +707,10 @@ func TestExamples(t *testing.T) {
 		}
 	}
 }`))
+	if err != nil {
+		t.Errorf("Error: %v", err)
+		return
+	}
 
 	var value float64
 	var ok bool
@@ -1575,7 +1579,10 @@ dynamic approach.
 func BenchmarkStatic(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var jsonObj jsonStructure
-		json.Unmarshal(jsonContent, &jsonObj)
+		if err := json.Unmarshal(jsonContent, &jsonObj); err != nil {
+			b.Errorf("Error: %v", err)
+			return
+		}
 
 		if val := jsonObj.FirstOutter.SecondInner.NumberType; val != 12 {
 			b.Errorf("Wrong value of FirstOutter.SecondInner.NumberType: %v\n", val)

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -38,7 +38,7 @@ func TestBasic(t *testing.T) {
 		t.Errorf("Didn't find test2")
 	}
 
-	if result := val.Bytes(); string(result) != string(sample) {
+	if result := val.Bytes(); !bytes.Equal(result, sample) {
 		t.Errorf("Wrong []byte conversion: %s != %s", result, sample)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/Jeffail/gabs/v2
+
+go 1.13


### PR DESCRIPTION
Thought to add some linting and CI to this one too.

~I guess 93f81fa might have caused trouble in some cases, because the underlying data of slices is passed by reference.~ On second thought, after playing with some similar code a bit, I think the compiler is smart enough to do the right thing. I can revert to the original implementation and add a linter exception if you prefer that.

Also, there are a bunch of functions called in the tests which aren't checked for errors and I ignored them for now. Happy to add those checks if you don't mind the extra verbosity.