### PR TITLE
Optimize wildcard search executions

### DIFF
--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1622,6 +1622,23 @@ func BenchmarkDynamic(b *testing.B) {
 	}
 }
 
+func BenchmarkWildcardSearch(b *testing.B) {
+	sample := []byte(`{"test":[{"value":10},{"value":20}]}`)
+
+	val, err := ParseJSON(sample)
+	if err != nil {
+		b.Fatalf("Failed to parse: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		val.Search([]string{"test", "*"}...)
+		val.Search([]string{"test", "*", "value"}...)
+	}
+}
+
 func TestBadIndexes(t *testing.T) {
 	jsonObj, err := ParseJSON([]byte(`{"array":[1,2,3]}`))
 	if err != nil {


### PR DESCRIPTION
This PR makes wildcard searches significantly faster by reducing heap allocations where possible.

`searchStrict` logic has been encapsulated in a function that returns `interface{}` instead of `*Container` as the first returned parameter. This avoids the unnecessary wrapping/unwrapping.

Also, when handling a wildcard as the last path segment, array values are no longer copied. Instead the array is returned directly and then wrapped in a `Container`. This removes another allocation.

`BenchmarkWildcardSearch` has been added to assess the improvements.

Before the change:
> BenchmarkWildcardSearch-16         2838511           413.2 ns/op       240 B/op         12 allocs/op

After the change:
> BenchmarkWildcardSearch-16       5705732           201.8 ns/op       112 B/op          5 allocs/op