### PR TITLE
Use strings.Replacer to allocate Replace up front instead of in each loop iteration.

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -24,13 +24,14 @@ package gabs
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"strconv"
 	"strings"
+
+	"github.com/goccy/go-json"
 )
 
 //------------------------------------------------------------------------------
@@ -76,6 +77,16 @@ var (
 	ErrInvalidBuffer = errors.New("input buffer contained invalid JSON")
 )
 
+var (
+	r1 *strings.Replacer
+	r2 *strings.Replacer
+)
+
+func init() {
+	r1 = strings.NewReplacer("~1", "/", "~0", "~")
+	r2 = strings.NewReplacer("~1", ".", "~0", "~")
+}
+
 //------------------------------------------------------------------------------
 
 // JSONPointerToSlice parses a JSON pointer path
@@ -97,9 +108,7 @@ func JSONPointerToSlice(path string) ([]string, error) {
 	}
 	hierarchy := strings.Split(path, "/")[1:]
 	for i, v := range hierarchy {
-		v = strings.Replace(v, "~1", "/", -1)
-		v = strings.Replace(v, "~0", "~", -1)
-		hierarchy[i] = v
+		hierarchy[i] = r1.Replace(v)
 	}
 	return hierarchy, nil
 }
@@ -112,9 +121,7 @@ func JSONPointerToSlice(path string) ([]string, error) {
 func DotPathToSlice(path string) []string {
 	hierarchy := strings.Split(path, ".")
 	for i, v := range hierarchy {
-		v = strings.Replace(v, "~1", ".", -1)
-		v = strings.Replace(v, "~0", "~", -1)
-		hierarchy[i] = v
+		hierarchy[i] = r2.Replace(v)
 	}
 	return hierarchy
 }

--- a/gabs.go
+++ b/gabs.go
@@ -24,14 +24,13 @@ package gabs
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"strconv"
 	"strings"
-
-	"github.com/goccy/go-json"
 )
 
 //------------------------------------------------------------------------------

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -2,11 +2,12 @@ package gabs
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/goccy/go-json"
 )
 
 func TestBasic(t *testing.T) {
@@ -1573,6 +1574,7 @@ dynamic approach.
 */
 
 func BenchmarkStatic(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		var jsonObj jsonStructure
 		json.Unmarshal(jsonContent, &jsonObj)
@@ -1595,6 +1597,7 @@ func BenchmarkStatic(b *testing.B) {
 }
 
 func BenchmarkDynamic(b *testing.B) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		jsonObj, err := ParseJSON(jsonContent)
 		if err != nil {

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -2,12 +2,11 @@ package gabs
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/goccy/go-json"
 )
 
 func TestBasic(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,5 @@
 module github.com/Jeffail/gabs/v2
+
+go 1.18
+
+require github.com/goccy/go-json v0.9.11

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/Jeffail/gabs/v2
 
 go 1.18
-
-require github.com/goccy/go-json v0.9.11


### PR DESCRIPTION
~Instead of using encoding/json, switch to go-json.~

Use a strings.Replacer instead of multiple calls to strings.Replace.