### PR TITLE
preallocate tmparray to avoid allocation in loop

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -148,17 +148,22 @@ func (g *Container) searchStrict(allowWildcard bool, hierarchy ...string) (*Cont
 			}
 		} else if marray, ok := object.([]interface{}); ok {
 			if allowWildcard && pathSeg == "*" {
-				tmpArray := []interface{}{}
-				for _, val := range marray {
-					if (target + 1) >= len(hierarchy) {
-						tmpArray = append(tmpArray, val)
-					} else if res := Wrap(val).Search(hierarchy[target+1:]...); res != nil {
-						tmpArray = append(tmpArray, res.Data())
+				var tmpArray []interface{}
+				if (target + 1) >= len(hierarchy) {
+					tmpArray = marray
+				} else {
+					tmpArray = make([]interface{}, 0, len(marray))
+					for _, val := range marray {
+						if res := Wrap(val).Search(hierarchy[target+1:]...); res != nil {
+							tmpArray = append(tmpArray, res.Data())
+						}
 					}
 				}
+
 				if len(tmpArray) == 0 {
 					return nil, nil
 				}
+
 				return &Container{tmpArray}, nil
 			}
 			index, err := strconv.Atoi(pathSeg)

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1904,3 +1904,20 @@ func TestFlattenIncludeEmpty(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkWildcardSearch(b *testing.B) {
+	sample := []byte(`{"test":[{"value":10},{"value":20}]}`)
+
+	val, err := ParseJSON(sample)
+	if err != nil {
+		b.Fatalf("Failed to parse: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		val.Search([]string{"test", "*"}...)
+		val.Search([]string{"test", "*", "value"}...)
+	}
+}


### PR DESCRIPTION
Preallocate tmpArray in searchStrict to avoid allocation each iteration.

Top: main, Bottom: main \w prealloc patch:
![image](https://user-images.githubusercontent.com/38172634/212489216-68f65b34-1fbc-43ed-9325-42fb319c2e2e.png)

WildcardSearch benchmark copied from #115 