### PR TITLE
Pre-allocate array in Children() for mmap and add benchmark.

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -255,11 +255,9 @@ func (g *Container) Children() []*Container {
 		return children
 	}
 	if mmap, ok := g.Data().(map[string]interface{}); ok {
-		children := make([]*Container, len(mmap))
-		i := 0
+		children := make([]*Container, 0, len(mmap))
 		for _, obj := range mmap {
-			children[i] = &Container{obj}
-			i++
+			children = append(children, &Container{obj})
 		}
 		return children
 	}

--- a/gabs.go
+++ b/gabs.go
@@ -256,8 +256,10 @@ func (g *Container) Children() []*Container {
 	}
 	if mmap, ok := g.Data().(map[string]interface{}); ok {
 		children := make([]*Container, len(mmap))
+		i := 0
 		for _, obj := range mmap {
-			children = append(children, &Container{obj})
+			children[i] = &Container{obj}
+			i++
 		}
 		return children
 	}

--- a/gabs.go
+++ b/gabs.go
@@ -255,7 +255,7 @@ func (g *Container) Children() []*Container {
 		return children
 	}
 	if mmap, ok := g.Data().(map[string]interface{}); ok {
-		children := []*Container{}
+		children := make([]*Container, len(mmap))
 		for _, obj := range mmap {
 			children = append(children, &Container{obj})
 		}

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1904,3 +1904,22 @@ func TestFlattenIncludeEmpty(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkChildren(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		jsonObj, err := ParseJSON(bigSample)
+		if err != nil {
+			b.Errorf("Error parsing json: %v\n", err)
+		}
+
+		_ = jsonObj.Children()
+
+		FOSI := jsonObj.S("firstOutter", "secondInner")
+		_ = FOSI.Children()
+		SOSI := jsonObj.S("secondOutter", "secondInner")
+		_ = SOSI.Children()
+		SOTI := jsonObj.S("secondOutter", "thirdInner")
+		_ = SOTI.Children()
+	}
+}


### PR DESCRIPTION
Pre-allocate mmap in Container.Children() and add Benchmark.

Top: main, Bottom: main \w Pre-allocate patch:
![image](https://user-images.githubusercontent.com/38172634/212490709-5d026d1a-ed53-48da-aa4b-2447ea0d4c12.png)
