### PR TITLE
Add LRU cache for JSONPointerToSlice and DotPathToSlice.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1950,3 +1950,37 @@ func BenchmarkWildcardSearch(b *testing.B) {
 		val.Search([]string{"test", "*", "value"}...)
 	}
 }
+
+func BenchmarkJsonPointerToSlice(b *testing.B) {
+	samples := []string{
+		"/test/field",
+		"/field/test",
+		"/user/name",
+		"/user/email/address",
+		"/host/ip/addres",
+		"/host/os/family",
+		"/host/os/version",
+		"/test/field",
+		"/field/test",
+		"/user/name",
+		"/user/email/address",
+		"/host/ip/addres",
+		"/host/os/family",
+		"/host/os/version",
+		"/test/field",
+		"/field/test",
+		"/user/name",
+		"/user/email/address",
+		"/host/ip/addres",
+		"/host/os/family",
+		"/host/os/version",
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, s := range samples {
+			JSONPointerToSlice(s)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Jeffail/gabs/v2
 
-go 1.16
+go 1.18
+
+require github.com/hashicorp/golang-lru/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/hashicorp/golang-lru/v2 v2.0.2 h1:Dwmkdr5Nc/oBiXgJS3CDHNhJtIHkuZ3DZF5twqnfBdU=
+github.com/hashicorp/golang-lru/v2 v2.0.2/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=


### PR DESCRIPTION
This caches DotPathToSlice and JSONPointerToSlice to prevent unnecessary allocations and string replacements on paths/pointers that are frequently looked up.

