### PR TITLE
Match Wrap container to comparable New container

### DIFF
--- a/gabs.go
+++ b/gabs.go
@@ -870,7 +870,11 @@ func New() *Container {
 // Wrap an already unmarshalled JSON object (or a new map[string]interface{})
 // into a *Container.
 func Wrap(root interface{}) *Container {
-	return &Container{root}
+	b, _ := json.Marshal(root)
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+
+	return &Container{m}
 }
 
 // ParseJSON unmarshals a JSON byte slice into a *Container.

--- a/gabs_test.go
+++ b/gabs_test.go
@@ -1915,6 +1915,50 @@ func TestFlattenIncludeEmpty(t *testing.T) {
 	}
 }
 
+func TestWrapAgainstNew(t *testing.T) {
+	exp := New()
+
+	exp.Set(1, "A")
+	exp.SetP(2, "B")
+	exp.SetP("3", "Alpha.Beta")
+	exp.SetP(3.14, "Alpha.Gamma")
+
+	if err := exp.Delete("B"); err != nil {
+		t.Error(err)
+	}
+	if err := exp.DeleteP("Alpha.Beta"); err != nil {
+		t.Error(err)
+	}
+
+	type toWrap struct {
+		A     int
+		B     int
+		Alpha struct {
+			Beta  string
+			Gamma *float64
+		}
+	}
+
+	gamma := 3.14
+
+	act := Wrap(toWrap{A: 1, B: 2, Alpha: struct {
+		Beta  string
+		Gamma *float64
+	}{Beta: "3", Gamma: &gamma}})
+
+	if err := act.Delete("B"); err != nil {
+		panic(err)
+	}
+	if err := act.DeleteP("Alpha.Beta"); err != nil {
+		t.Error(err)
+	}
+
+	if exp.String() != act.String() {
+		t.Errorf("Wrong result: %v != %v", act, exp)
+	}
+
+}
+
 func BenchmarkChildren(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
#141

This change encapsulates data given to `.Wrap()` in a map[string]interface{}, similar to the structure a container created by `.New()`.
Marshalling and unmarshalling is probably not the most efficient way to do this and there may be some value in adding type assertions via reflection, but I am not one to bring the baggage of reflect to someone else's project.